### PR TITLE
Fix phpunit version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0",
-        "phpunit/phpunit": "^8.0|^8.0"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Just noticed this was requiring `^8.0|^8.0` for the PHPUnit in dev builds when it should've probably been `^8.0|^9.0` for the newer version of PHPUnit.