### PR TITLE
Add PHP 8.1 Support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: spatie
 custom: https://spatie.be/open-source/support-us

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: dependabot-auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+    
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          
+      - name: Auto-merge Dependabot PRs for semver-minor updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          
+      - name: Auto-merge Dependabot PRs for semver-patch updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,23 +1,23 @@
 name: Check & fix styling
 
-on: [ push ]
+on: [push]
 
 jobs:
-    php-cs-fixer:
-        runs-on: ubuntu-latest
+  php-cs-fixer:
+    runs-on: ubuntu-latest
 
-        steps:
-            -   name: Checkout code
-                uses: actions/checkout@v2
-                with:
-                    ref: ${{ github.head_ref }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
 
-            -   name: Run PHP CS Fixer
-                uses: docker://oskarstark/php-cs-fixer-ga
-                with:
-                    args: --config=.php_cs.dist --allow-risky=yes
+      - name: Run PHP CS Fixer
+        uses: docker://oskarstark/php-cs-fixer-ga
+        with:
+          args: --config=.php-cs-fixer.dist.php --allow-risky=yes
 
-            -   name: Commit changes
-                uses: stefanzweifel/git-auto-commit-action@v4
-                with:
-                    commit_message: Fix styling
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Fix styling

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
                     -   laravel: 8.*
                         testbench: ^6.23
                     -   laravel: 7.*
-                        testbench: 5.*
+                        testbench: ^5.20
                 exclude:
                   - laravel: 7.*
                     php: 8.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,10 +13,13 @@ jobs:
                 laravel: [8.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
-                    -   laravel: 8.*
-                        testbench: 6.*
+                    -   laravel: ^8.73
+                        testbench: ^6.23
                     -   laravel: 7.*
                         testbench: 5.*
+                exclude:
+                    -   laravel: 7.*
+                        php: 8.1
                         
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.4, 8.0]
+                php: [8.1, 8.0, 7.4]
                 laravel: [8.*, 6.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
@@ -19,7 +19,7 @@ jobs:
                         testbench: 5.*
                     -   laravel: 6.*
                         testbench: 4.*
-
+                        
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
@@ -42,7 +42,7 @@ jobs:
             -   name: Install dependencies
                 run: |
                     composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Execute tests
                 run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,15 +10,13 @@ jobs:
             matrix:
                 os: [ubuntu-latest, windows-latest]
                 php: [8.1, 8.0, 7.4]
-                laravel: [8.*, 6.*, 7.*]
+                laravel: [8.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
                         testbench: 6.*
                     -   laravel: 7.*
                         testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
                         
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,13 +13,13 @@ jobs:
                 laravel: [8.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
-                    -   laravel: ^8.73
+                    -   laravel: 8.*
                         testbench: ^6.23
                     -   laravel: 7.*
                         testbench: 5.*
                 exclude:
-                    -   laravel: 7.*
-                        php: 8.1
+                  - laravel: 7.*
+                    php: 8.1
                         
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,28 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ build
 composer.lock
 docs
 vendor
-.php_cs.cache
+*.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,26 +1,22 @@
 <?php
 
 $finder = Symfony\Component\Finder\Finder::create()
-    ->notPath('bootstrap/*')
-    ->notPath('storage/*')
-    ->notPath('resources/view/mail/*')
     ->in([
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
     ->name('*.php')
-    ->notName('*.blade.php')
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
-        '@PSR2' => true,
+        '@PSR12' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,
         'not_operator_with_successor_space' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => true,
         'phpdoc_scalar' => true,
         'unary_operator_spaces' => true,
         'binary_operator_spaces' => true,
@@ -29,9 +25,15 @@ return PhpCsFixer\Config::create()
         ],
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_var_without_name' => true,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method' => 'one',
+            ],
+        ],
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
             'keep_multiple_spaces_after_comma' => true,
-        ]
+        ],
+        'single_trait_insert_per_statement' => true,
     ])
     ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "laravel/framework": "^6.0|^7.0|^8.0"
+        "php": "^7.4|^8.0|^8.0",
+        "laravel/framework": "^6.20|^7.30|^8.73"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^8.0|^9.0|^9.3"
+        "orchestra/testbench": "^4.18|^5.20|^6.23",
+        "phpunit/phpunit": "^8.5|^9.0|^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     ],
     "require": {
         "php": "^7.4|^8.0|^8.0",
-        "laravel/framework": "^6.20|^7.30|^8.73"
+        "laravel/framework": "^7.30|^8.73"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.18|^5.20|^6.23",
-        "phpunit/phpunit": "^8.5|^9.0|^9.5"
+        "orchestra/testbench": "^5.20|^6.23",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    executionOrder="random"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnEmptyTestSuite="true"
+    beStrictAboutOutputDuringTests="true"
+    verbose="true"
+>
     <testsuites>
-        <testsuite name="Spatie Test Suite">
+        <testsuite name="VendorName Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
 </phpunit>


### PR DESCRIPTION
This PR adds PHP 8.1 support to the run tests workflow.

Additionally, it:
- adds the `dependabot` config & workflow
- adds the update changelog workflow
- updates the `php-cs-fixer` config & workflow
- updates the `PHPUnit` config to the latest schema
- bumps dependency versions in `composer.json`
- **drops support for PHP 7.2 and 7.3**
- **drops Laravel 6.x support**
- **Laravel 7.x is supported only by PHP 8.0 and below**

_This repository needs its primary branch renamed from `master` to `main`._