### PR TITLE
Update installation instructions for Laravel 11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,14 @@ You can install the package via composer:
 composer require spatie/laravel-artisan-dd
 ```
 
-You must register the `Spatie\ArtisanDd\DdCommand` in the console kernel.
+You must register the `Spatie\ArtisanDd\DdCommand` in the bootstrap file:
 
 ```php
-// app/Console/Kernel.php
+// bootstrap/app.php
 
-protected $commands = [
-    ...
+->withCommands([
     \Spatie\ArtisanDd\DdCommand::class,
-];
+])
 ```
 
 ## Usage


### PR DESCRIPTION
Since `app/Console/Kernel.php` no longer exists by default, it would be good to update the instructions to match.

I haven't included "If you are using Laravel 10: _old instructions_" since Laravel 10 is now EOL - but could if you would prefer that.

Thanks!